### PR TITLE
Fix article link for private-api setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ touch $HOME/.gradle/gradle.properties
 echo "omdb_apikey=\"<API_KEY_GOES_HERE>\"" >> $HOME/.gradle/gradle.properties
 ```
 
-You can read [this post for instructions](https://medium.com/code-better/hiding-api-keys-from-your-android-repository-b23f5598b906) on this private api
+You can read [this post for instructions](https://varunbarad.com/android/2018/02/01/hiding-api-keys-from-your-android-repository.html) on this private api
 setting up process.
 
 For great movie recommendations, ping me [@kaushikgopal](https://twitter.com/kaushikgopal) (seriously, I watch a lot of movies).


### PR DESCRIPTION
I am the author of the article for setting up private api-keys.
I have deleted my Medium account and thus the article is not available on the original link anymore.
I have updated the link to point to a working copy.