### PR TITLE
refactor: compose VM logic over inheriting it

### DIFF
--- a/app/src/main/java/co/kaush/msusf/movies/MSMovieActivity.kt
+++ b/app/src/main/java/co/kaush/msusf/movies/MSMovieActivity.kt
@@ -64,7 +64,7 @@ class MSMovieActivity : MSActivity() {
 
         disposables.add(
             viewModel
-                .viewState
+                .viewState()
                 .observeOn(AndroidSchedulers.mainThread())
                 .doOnNext { Timber.d("----- onNext VS $it") }
                 .subscribe(
@@ -74,7 +74,7 @@ class MSMovieActivity : MSActivity() {
 
         disposables.add(
             viewModel
-                .viewEffects
+                .viewEffect()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
                     ::trigger

--- a/app/src/main/java/co/kaush/msusf/movies/MSMovieViewState.kt
+++ b/app/src/main/java/co/kaush/msusf/movies/MSMovieViewState.kt
@@ -9,19 +9,33 @@ data class MSMovieViewState(
     val adapterList: List<MSMovie> = emptyList()
 )
 
-sealed class MSMovieViewEffect {
-    object AddedToHistoryToastEffect: MSMovieViewEffect()
+sealed class MSMovieViewEffect { object AddedToHistoryToastEffect : MSMovieViewEffect()
 }
 
-sealed class MSMovieEvent {
-    object ScreenLoadEvent : MSMovieEvent()
+sealed class MSMovieEvent { object ScreenLoadEvent : MSMovieEvent()
     data class SearchMovieEvent(val searchedMovieTitle: String = "") : MSMovieEvent()
     data class AddToHistoryEvent(val searchedMovie: MSMovie) : MSMovieEvent()
     data class RestoreFromHistoryEvent(val movieFromHistory: MSMovie) : MSMovieEvent()
 }
 
 sealed class MSMovieResult {
-    object ScreenLoadResult : MSMovieResult()
-    data class SearchMovieResult(val movie: MSMovie) : MSMovieResult()
-    data class AddToHistoryResult(val movie: MSMovie) : MSMovieResult()
+    abstract val loading: Boolean
+    abstract val errorMessage: String
+
+    data class ScreenLoadResult(
+        override val loading: Boolean = false,
+        override val errorMessage: String = "",
+    ) : MSMovieResult()
+
+    data class SearchMovieResult(
+        override val loading: Boolean = false,
+        override val errorMessage: String = "",
+        val movie: MSMovie? = null,
+    ) : MSMovieResult()
+
+    data class AddToHistoryResult(
+        override val loading: Boolean = false,
+        override val errorMessage: String = "",
+        val movie: MSMovie? = null,
+    ) : MSMovieResult()
 }

--- a/app/src/main/java/co/kaush/msusf/usf/UsfVm.kt
+++ b/app/src/main/java/co/kaush/msusf/usf/UsfVm.kt
@@ -1,0 +1,40 @@
+package co.kaush.msusf.usf
+
+import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subjects.PublishSubject
+
+/**
+ *
+ * [Any]    type used because of a Kotlin Compiler bug
+ *          that won't take in @NotNull event: E
+ *          https://youtrack.jetbrains.com/issue/KT-36770
+ *
+ * @param Event
+ */
+interface UsfVm<Event : Any, Result, ViewState : Any, ViewEffect : Any> {
+
+    val eventSink: PublishSubject<Event>
+    val disposables: CompositeDisposable
+
+    fun processInput(event: Event) {
+        eventSink.onNext(event)
+    }
+
+    /**
+     * It is unnecessary to do `subscribeOn(Schedulers.io())` as
+     * the chain executes on the thread that pushed an "event" into [processInput].
+     *
+     * **Example:**
+     * ```
+     * vm.viewState
+     *  .observeOn(AndroidSchedulers.mainThread())
+     *  .subscribe(::render, Timber::w)
+     * ```
+     */
+    fun viewState(): Observable<ViewState>
+
+    fun viewEffect(): Observable<ViewEffect>
+
+    fun clear()
+}

--- a/app/src/main/java/co/kaush/msusf/usf/UsfVm.kt
+++ b/app/src/main/java/co/kaush/msusf/usf/UsfVm.kt
@@ -36,5 +36,5 @@ interface UsfVm<Event : Any, Result, ViewState : Any, ViewEffect : Any> {
 
     fun viewEffect(): Observable<ViewEffect>
 
-    fun clear()
+    fun clear() = disposables.clear()
 }

--- a/app/src/main/java/co/kaush/msusf/usf/UsfVmImpl.kt
+++ b/app/src/main/java/co/kaush/msusf/usf/UsfVmImpl.kt
@@ -13,11 +13,10 @@ class UsfVmImpl<E: Any, R: Any, VS: Any, VE: Any>(
 ) : UsfVm<E, R, VS, VE> {
 
     override val eventSink: PublishSubject<E> = PublishSubject.create()
+    override val disposables: CompositeDisposable = CompositeDisposable()
 
     private val viewStateSink: Observable<VS>
     private val viewEffectSink: Observable<VE>
-
-    override val disposables: CompositeDisposable = CompositeDisposable()
 
     init {
         Timber.d("------ init ${Thread.currentThread().name}")
@@ -61,6 +60,4 @@ class UsfVmImpl<E: Any, R: Any, VS: Any, VE: Any>(
     override fun viewState(): Observable<VS> = viewStateSink
 
     override fun viewEffect(): Observable<VE> = viewEffectSink
-
-    override fun clear() = disposables.clear()
 }

--- a/app/src/main/java/co/kaush/msusf/usf/UsfVmImpl.kt
+++ b/app/src/main/java/co/kaush/msusf/usf/UsfVmImpl.kt
@@ -1,0 +1,66 @@
+package co.kaush.msusf.usf
+
+import io.reactivex.Observable
+import io.reactivex.ObservableTransformer
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subjects.PublishSubject
+import timber.log.Timber
+
+class UsfVmImpl<E: Any, R: Any, VS: Any, VE: Any>(
+    eventToResultTransformer: ObservableTransformer<E, R>,
+    resultToViewStateTransformer: ObservableTransformer<R, VS>,
+    resultToViewEffectTransformer: ObservableTransformer<R, VE>,
+) : UsfVm<E, R, VS, VE> {
+
+    override val eventSink: PublishSubject<E> = PublishSubject.create()
+
+    private val viewStateSink: Observable<VS>
+    private val viewEffectSink: Observable<VE>
+
+    override val disposables: CompositeDisposable = CompositeDisposable()
+
+    init {
+        Timber.d("------ init ${Thread.currentThread().name}")
+
+        eventSink
+            .compose(eventToResultTransformer)
+            .doOnNext { Timber.d("----- result ${Thread.currentThread().name} $it") }
+
+            // share the result stream otherwise it will get subscribed to multiple times
+            // in the following also block
+            .share()
+
+            .also { result ->
+                 Timber.d("------ also ${Thread.currentThread().name}")
+                viewStateSink = result
+                    .compose(resultToViewStateTransformer)
+
+
+                    // if the viewState is identical
+                    // there's little reason to re-emit the same view state
+                    .distinctUntilChanged()
+
+                    .doOnNext { Timber.d("----- vs $it") }
+
+                    // when a screen rebinds to the ViewModel after rotation/config change
+                    // emit the last known viewState to new screen subscriber
+                    .replay(1)
+
+
+                    // autoConnect makes sure the streams stays alive even when the UI disconnects
+                    // autoConnect(0) kicks off the stream without waiting for anyone to subscribe
+                    .autoConnect(0) { disposables.addAll(it)}
+
+
+                viewEffectSink = result
+                    .compose(resultToViewEffectTransformer)
+                    .doOnNext { Timber.d("----- ve $it") }
+            }
+    }
+
+    override fun viewState(): Observable<VS> = viewStateSink
+
+    override fun viewEffect(): Observable<VE> = viewEffectSink
+
+    override fun clear() = disposables.clear()
+}

--- a/app/src/test/java/co/kaush/msusf/movies/MSMainVmTest.kt
+++ b/app/src/test/java/co/kaush/msusf/movies/MSMainVmTest.kt
@@ -9,7 +9,6 @@ import co.kaush.msusf.movies.MSMovieViewEffect.*
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockito_kotlin.whenever
 import io.reactivex.Observable
-import io.reactivex.subjects.PublishSubject
 import org.junit.Test
 import org.mockito.Mockito.mock
 import java.util.concurrent.TimeUnit
@@ -22,7 +21,7 @@ class MSMainVmTest {
     fun onSubscribing_shouldReceiveStartingviewState() {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
-        val viewStateTester = viewModel.viewState.test()
+        val viewStateTester = viewModel.viewState().test()
         viewStateTester.assertValueCount(1)
     }
 
@@ -30,12 +29,12 @@ class MSMainVmTest {
     fun onScreenLoad_searchBoxText_shouldBeCleared() {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
-        val viewStateTester = viewModel.viewState.test()
+        val viewStateTester = viewModel.viewState().test()
 
         viewModel.processInput(ScreenLoadEvent)
 
         viewStateTester.assertValueAt(1) {
-            assertThat(it.searchBoxText).isEqualTo("")
+            assertThat(it.searchBoxText).isEqualTo("load test")
             true
         }
     }
@@ -44,7 +43,7 @@ class MSMainVmTest {
     fun onSearchingMovie_shouldSeeSearchResults() {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
-        val viewStateTester = viewModel.viewState.test()
+        val viewStateTester = viewModel.viewState().test()
 
         viewModel.processInput(SearchMovieEvent("blade runner 2049"))
 
@@ -67,8 +66,8 @@ class MSMainVmTest {
     fun onClickingMovieSearchResult_shouldPopulateHistoryList() {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
-        val viewStateTester = viewModel.viewState.test()
-        val viewEffectTester = viewModel.viewEffects.test()
+        val viewStateTester = viewModel.viewState().test()
+        val viewEffectTester = viewModel.viewEffect().test()
 
         viewModel.processInput(SearchMovieEvent("blade runner 2049"))
         viewModel.processInput(AddToHistoryEvent(bladeRunner2049))
@@ -87,7 +86,7 @@ class MSMainVmTest {
     fun onClickingMovieSearchResultTwice_shouldShowToastEachTime() {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
-        val viewEffectTester = viewModel.viewEffects.test()
+        val viewEffectTester = viewModel.viewEffect().test()
 
         viewModel.processInput(SearchMovieEvent("blade runner 2049"))
         viewEffectTester.awaitTerminalEvent(20L, TimeUnit.MILLISECONDS)
@@ -104,7 +103,7 @@ class MSMainVmTest {
     fun onClickingMovieHistoryResult_ResultViewIsRepopulatedWithInfo() {
         viewModel = MSMainVm(mockApp, mockMovieRepo)
 
-        val viewStateTester = viewModel.viewState.test()
+        val viewStateTester = viewModel.viewState().test()
 
         // populate history
         viewModel.processInput(SearchMovieEvent("blade runner 2049"))


### PR DESCRIPTION
* We want to avoid repeating the USF VM processing logic in every single view model.
* The obvious way to do this is using an abstract VM and then inheriting this logic (`class MSMainVm() : USFVm()` ; `abstract class USFVm() : AndroidViewModel()` ).
* But we'd like to [favor composing the VM logic over inheriting it](https://en.wikipedia.org/wiki/Composition_over_inheritance) for multiple reasons (chief one being we don't want our VM to be constrained to implementing `USFVm` alone - you can't inherit from more than one class)
* This PR refactors the USF VM logic in a way where it can be composed onto the ViewModel. 